### PR TITLE
Update README.md

### DIFF
--- a/CIP10/README.md
+++ b/CIP10/README.md
@@ -53,6 +53,9 @@ transaction_metadatum_label | description
 1967                        | nut.link metadata oracles registry
 1968                        | nut.link metadata oracles data points
 65536 - 131071              | reserved - private use
+161815161519112             | Crypto2099 Voting Proposal
+22152051819                 | Crypto2099 Voter Registration
+211212152001 - 211212152099 | Crypto2099 Vote Ballot(s)
 
 \* It's best to avoid using `0` or any a similar number like `1` that other people are very likely to use. Prefer instead to generate a random number
 

--- a/CIP10/README.md
+++ b/CIP10/README.md
@@ -50,10 +50,11 @@ These are the registered `transaction_metadatum_label` values
 transaction_metadatum_label | description
 ----------------------------|-----------------------
 0 - 15                      | reserved*
+411                         | General information metadata
 1967                        | nut.link metadata oracles registry
 1968                        | nut.link metadata oracles data points
 65536 - 131071              | reserved - private use
-161815161519112             | Crypto2099 Voting Proposal
+161815161519112             | Crypto2099 Vote Proposal
 22152051819                 | Crypto2099 Voter Registration
 211212152001 - 211212152099 | Crypto2099 Vote Ballot(s)
 


### PR DESCRIPTION
Adding metadata label reservations for Crypto2099 On-Chain Voting mechanism (https://vote.crypto2099.io)

Reserved 98 slots for submission of voting ballots to support the "Vote by Dust" or other potential future use cases where multiple votes may be submitted in a single transaction.